### PR TITLE
🗃️ Quick Suggestion for DB updates to add support for the assessment

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -182,7 +182,7 @@ model AssessmentAreaQuestion {
   id               Int            @id @default(autoincrement())
   assessmentAreaId Int
   question         String
-  answer           String?
+  answer           Int?
   assessmentArea   AssessmentArea @relation(fields: [assessmentAreaId], references: [id], onDelete: Cascade)
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,14 +51,16 @@ model Session {
 }
 
 model User {
-  id            String    @id @default(cuid())
+  id            String        @id @default(cuid())
   name          String?
-  email         String?   @unique
+  email         String?       @unique
   emailVerified DateTime?
   image         String?
   accounts      Account[]
   posts         Post[]
   sessions      Session[]
+  assessments   Assessment[]
+  projects      UserProject[]
 }
 
 model VerificationToken {
@@ -126,28 +128,41 @@ model Area {
 
 model Stage {
   stageNumber Int
-  id          Int    @id @default(autoincrement())
-  name        String @unique
+  id          Int     @id @default(autoincrement())
+  name        String  @unique
   areas       Area[]
+  Score       Score[]
 }
 
 // New Models
 
 model Project {
-  id          Int          @id @default(autoincrement())
-  projectId   String       @unique
+  id          Int           @id @default(autoincrement())
+  projectId   String        @unique
   name        String
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
   assessments Assessment[]
+  users       UserProject[]
+}
+
+model UserProject {
+  userId    String
+  projectId Int
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@id([userId, projectId])
 }
 
 model Assessment {
   id        Int                  @id @default(autoincrement())
   projectId Int
+  userId    String
   createdAt DateTime             @default(now())
   updatedAt DateTime             @updatedAt
   project   Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user      User                 @relation(fields: [userId], references: [id])
   artefacts AssessmentArtefact[]
   areas     AssessmentArea[]
   Score     Score[]
@@ -191,10 +206,12 @@ model Score {
   assessmentId Int
   areaId       Int?
   artefactId   Int?
+  stageId      Int?
   score        Float
   assessment   Assessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade)
   area         Area?      @relation(fields: [areaId], references: [id])
   artefact     Artefact?  @relation(fields: [artefactId], references: [id])
+  stage        Stage?     @relation(fields: [stageId], references: [id])
 
-  @@unique([assessmentId, areaId, artefactId])
+  @@unique([assessmentId, areaId, artefactId, stageId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model User {
   email         String?       @unique
   emailVerified DateTime?
   image         String?
-  role          String        @default("Assessee")
+  role          String        @default("assessee")
   accounts      Account[]
   posts         Post[]
   sessions      Session[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,17 +12,6 @@ datasource db {
   directUrl = env("DIRECT_URL")
 }
 
-model Post {
-  id          Int      @id @default(autoincrement())
-  name        String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-  createdById String
-  createdBy   User     @relation(fields: [createdById], references: [id])
-
-  @@index([name])
-}
-
 model Account {
   id                       String  @id @default(cuid())
   userId                   String
@@ -58,7 +47,6 @@ model User {
   image         String?
   role          String        @default("assessee")
   accounts      Account[]
-  posts         Post[]
   sessions      Session[]
   assessments   Assessment[]
   projects      UserProject[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,7 +82,7 @@ model Standard {
 }
 
 model Artefact {
-  id                       Int        @id @default(autoincrement())
+  id                       Int                  @id @default(autoincrement())
   artefact_id              String
   artefact_name            String
   stage                    String
@@ -94,15 +94,16 @@ model Artefact {
   automation               String
   artefact_area_id         String
   areaId                   Int
-  artefact_area            Area       @relation(fields: [areaId], references: [id])
+  artefact_area            Area                 @relation(fields: [areaId], references: [id])
   standards                Standard[]
+  AssessmentArtefact       AssessmentArtefact[]
+  Score                    Score[]
 
   @@unique([artefact_id, artefact_name, stage])
 }
 
-
 model Area {
-  id                   Int        @id @default(autoincrement())
+  id                   Int              @id @default(autoincrement())
   area_id              String
   area_name            String
   people               String
@@ -115,16 +116,85 @@ model Area {
   question             String?
   assessors_guide      String?
   stageId              Int
-  stage                Stage      @relation(fields: [stageId], references: [id])
+  stage                Stage            @relation(fields: [stageId], references: [id])
   artefacts            Artefact[]
+  AssessmentArea       AssessmentArea[]
+  Score                Score[]
 
   @@unique([area_id, area_name, stageId])
 }
-
 
 model Stage {
   stageNumber Int
   id          Int    @id @default(autoincrement())
   name        String @unique
   areas       Area[]
+}
+
+// New Models
+
+model Project {
+  id          Int          @id @default(autoincrement())
+  projectId   String       @unique
+  name        String
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  assessments Assessment[]
+}
+
+model Assessment {
+  id        Int                  @id @default(autoincrement())
+  projectId Int
+  createdAt DateTime             @default(now())
+  updatedAt DateTime             @updatedAt
+  project   Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  artefacts AssessmentArtefact[]
+  areas     AssessmentArea[]
+  Score     Score[]
+}
+
+model AssessmentArtefact {
+  id           Int        @id @default(autoincrement())
+  artefactId   Int
+  assessmentId Int
+  checkmark    Boolean
+  comment      String?
+  artefact     Artefact   @relation(fields: [artefactId], references: [id])
+  assessment   Assessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade)
+
+  @@unique([artefactId, assessmentId])
+}
+
+model AssessmentArea {
+  id           Int                      @id @default(autoincrement())
+  areaId       Int
+  assessmentId Int
+  comment      String?
+  score        Float
+  area         Area                     @relation(fields: [areaId], references: [id])
+  assessment   Assessment               @relation(fields: [assessmentId], references: [id], onDelete: Cascade)
+  questions    AssessmentAreaQuestion[]
+
+  @@unique([areaId, assessmentId])
+}
+
+model AssessmentAreaQuestion {
+  id               Int            @id @default(autoincrement())
+  assessmentAreaId Int
+  question         String
+  answer           String?
+  assessmentArea   AssessmentArea @relation(fields: [assessmentAreaId], references: [id], onDelete: Cascade)
+}
+
+model Score {
+  id           Int        @id @default(autoincrement())
+  assessmentId Int
+  areaId       Int?
+  artefactId   Int?
+  score        Float
+  assessment   Assessment @relation(fields: [assessmentId], references: [id], onDelete: Cascade)
+  area         Area?      @relation(fields: [areaId], references: [id])
+  artefact     Artefact?  @relation(fields: [artefactId], references: [id])
+
+  @@unique([assessmentId, areaId, artefactId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model User {
   email         String?       @unique
   emailVerified DateTime?
   image         String?
+  role          String        @default("Assessee")
   accounts      Account[]
   posts         Post[]
   sessions      Session[]


### PR DESCRIPTION
Added the following Models:

- Project
- UserProject (bridge entity)
- Assessment
  - AssessmentArtefact
  - AssessmentArea 
- AssessmentAreaQuestion (because each Area would have multiple questions)
- Score (tentative shape, maybe add columns for scores per stage? needs some feedback) 


This is not pushed to the Database and it is not meant for a merge yet. We would like to first see if this is a good approach.

Check files changed so that it is easier to visualise the changes and additions, apologies for not including an ERD.

### Example Usage

- To store a score for an artefact within a particular assessment, create a `Score` entry with the `assessmentId` and `artefactId` set, leaving `areaId` and `stageId` null.
- To store a score for an area within a particular assessment, create a `Score` entry with the `assessmentId` and `areaId` set, leaving `artefactId` and `stageId` null.
- To store a score for a stage within a particular assessment, create a `Score` entry with the `assessmentId` and `stageId` set, leaving `areaId` and `artefactId` null.
- Aggregate scores at different levels using these relations, for example:
  - Sum scores for all artefacts under a specific area.
  - Sum scores for all areas under a specific stage.
  - Aggregate scores for all artefacts or areas within a specific assessment.
  - Aggregate scores for all areas and artefacts within a specific stage across assessments.
