### PR TITLE
Add role (default "assessee") to module User in prisma schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 
 # misc
 reference_model
+
+# npm
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,3 @@ yarn-error.log*
 
 # misc
 reference_model
-
-# npm
-package-lock.json

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,6 +56,7 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  role          String    @default("assessee")
   accounts      Account[]
   posts         Post[]
   sessions      Session[]
@@ -100,7 +101,6 @@ model Artefact {
   @@unique([artefact_id, artefact_name, stage])
 }
 
-
 model Area {
   id                   Int        @id @default(autoincrement())
   area_id              String
@@ -120,7 +120,6 @@ model Area {
 
   @@unique([area_id, area_name, stageId])
 }
-
 
 model Stage {
   stageNumber Int


### PR DESCRIPTION
As discussed, a UI for users to change their roles between assessor and assessee is not necessary. Therefore, merge this branch. The only two changes:
1. Add role (default "assessee") to module User in prisma schema, this change is already pushed to DB
![image](https://github.com/user-attachments/assets/b7dd84f6-3ff6-4a55-9c8c-42722935f0b9)
2. Add `package-lock.json` to `.gitignore`, as `pnpm` does not work on my machine and I have to use `npm`, which generate this file